### PR TITLE
Korrektur Rechtschreibfehler

### DIFF
--- a/content/20_bend_surface_mesh.tex
+++ b/content/20_bend_surface_mesh.tex
@@ -506,7 +506,7 @@ Dann gilt $b_n^n = B^n(t_0)$.
 \begin{figure}[H]
     \centering
     \input{images/xfig/deCasteljau.pdf_t}
-    \caption{Auswertung einer Beziekurve  zum Zeitpunkt $t_0$ durch itterative Streckenteilung nach de Casteljau} %TODO
+    \caption{Auswertung einer Beziekurve  zum Zeitpunkt $t_0$ durch iterative Streckenteilung nach de Casteljau} %TODO
     \label{fig:deCastel}
 \end{figure}
 


### PR DESCRIPTION
Anmerkung: Abbildung zur Auswertung der Bezierkurve muss korrigiert werden: b_3^3 = B^n(t_0) müsste b_3^3 = B^3(t_0) sein
